### PR TITLE
Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ### Unreleased
 
 
+### [1.3.3] - 2022-06-05
+
+- doc(README): use v1 tag instead of v1.2.0
+
+
 ### [1.3.2] - 2022-06-03
 
 - ci: add environment to publishing steps
@@ -47,3 +52,4 @@
 [1.3.0]: https://github.com/msimerson/node-lts-versions/releases/tag/1.3.0
 [1.3.1]: https://github.com/msimerson/node-lts-versions/releases/tag/1.3.1
 [1.3.2]: https://github.com/msimerson/node-lts-versions/releases/tag/1.3.2
+[1.3.3]: https://github.com/msimerson/node-lts-versions/releases/tag/1.3.3

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ At the time of writing, active=`[14,16,18]` and lts=`[14,16]`. Node.js v18 is du
     runs-on: ubuntu-latest
     steps:
       - id: get
-        uses: msimerson/node-lts-versions@v1.2.0
+        uses: msimerson/node-lts-versions@v1
     outputs:
       active: ${{ steps.get.outputs.active }}
       lts: ${{ steps.get.outputs.lts }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lts-versions",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Get the maintained LTS versions of Node.js",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- doc(README): use v1 tag instead of v1.2.0