### PR TITLE
Release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ### Unreleased
 
-
-### [1.4.0] - 2022-06-23
+### [1.4.1] - 2022-06-23
 
 - fix: only the first named output was being set.
 - chore(dep): bumped @actions/core to v1.9.0
@@ -59,4 +58,4 @@
 [1.3.1]: https://github.com/msimerson/node-lts-versions/releases/tag/1.3.1
 [1.3.2]: https://github.com/msimerson/node-lts-versions/releases/tag/1.3.2
 [1.3.3]: https://github.com/msimerson/node-lts-versions/releases/tag/1.3.3
-[1.4.0]: https://github.com/msimerson/node-lts-versions/releases/tag/1.4.0
+[1.4.1]: https://github.com/msimerson/node-lts-versions/releases/tag/1.4.1

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ At the time of writing, active=`[14,16,18]` and lts=`[14,16]`. Node.js v18 is du
 
 ```sh
 ✗ node main.js
-::set-output name=active::["14","16","18"] name=lts::["14","16"] name=min::"14"
+::set-output name=active::["14","16","18"]
+::set-output name=lts::["14","16"]
+::set-output name=min::"14"
 ```
 
 #### RAW

--- a/dist/index.js
+++ b/dist/index.js
@@ -142,12 +142,26 @@ module.exports = new getNodeLTS()
 /***/ 549:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
 
-// const core = require('@actions/core');
+const useCore = false
+
 const l=__nccwpck_require__(590)
 l.fetch().then(() => {
+  const lts    = l.json({lts: true})
   const active = l.json()
-  const min = JSON.stringify(JSON.parse(active)[0])
-  console.log(`::set-output name=active::${active} name=lts::${l.json({lts: true})} name=min::${min}`)
+  const min    = JSON.stringify(JSON.parse(active)[0])
+
+  if (useCore) {
+    // const core = require('@actions/core');
+    // core.setOutput('active', active)
+    // core.setOutput('lts'   , lts)
+    // core.setOutput('min'   , min)
+  }
+  else {
+    // console.log(`::set-output name=active::${active} name=lts::${lts} name=min::${min}`)
+    console.log(`::set-output name=active::${active}`)
+    console.log(`::set-output name=lts::${lts}`)
+    console.log(`::set-output name=min::${min}`)
+  }
 })
 
 

--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-const core = require('@actions/core');
 const useCore = false
 
 const l=require('./index')
@@ -8,9 +7,10 @@ l.fetch().then(() => {
   const min    = JSON.stringify(JSON.parse(active)[0])
 
   if (useCore) {
-    core.setOutput('active', active)
-    core.setOutput('lts'   , lts)
-    core.setOutput('min'   , min)
+    // const core = require('@actions/core');
+    // core.setOutput('active', active)
+    // core.setOutput('lts'   , lts)
+    // core.setOutput('min'   , min)
   }
   else {
     // console.log(`::set-output name=active::${active} name=lts::${lts} name=min::${min}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lts-versions",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Get the maintained LTS versions of Node.js",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- fix: only the first named output was being set
- bump @actions/core version to 1.9.0