### PR TITLE
Release v1.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,17 @@
 name: CI
 
-on: [ push ]
+on: [ push, pull_request ]
 
 env:
   CI: true
-  node-version: 20
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      name: Node.js ${{ env.node-version }}
-      with:
-        node-version: ${{ env.node-version }}
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      name: Node.js
     - run: npm install
     - run: npm run lint
       env:
@@ -26,11 +23,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ 18, 20 ]
+        node-version: [ 'lts/*', 'lts/-1' ]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
       with:
         node-version: ${{ matrix.node-version }}
@@ -42,10 +39,8 @@ jobs:
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: ${{ env.node-version }}
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
     - run: npm install
     - name: run coverage
       run: npx -y c8 --reporter=lcovonly npm test
@@ -53,7 +48,7 @@ jobs:
         NODE_ENV: cov
 
     - name: codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
 
     - name: coveralls.io
       uses: coverallsapp/github-action@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,18 +4,13 @@ on:
   release:
     types: [ published ]
 
-env:
-  node-version: 20
-
 jobs:
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: ${{ env.node-version }}
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
     - run: npm install
     - run: npm test
 
@@ -24,10 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: ${{ env.node-version }}
         registry-url: https://registry.npmjs.org
     - run: npm install
     - run: npm publish --ignore-scripts
@@ -43,10 +37,9 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: ${{ env.node-version }}
         registry-url: https://npm.pkg.github.com
         scope: "@msimerson"
     - run: npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 
 ### [1.6.2] - 2024-02-07
 
-- dep: actions/checkout@v3 -> v4
-- dep: actions/setup-node@v3 -> v4
-- dep: use new node-version `*` & `-1` syntax
-- dep: codecov/codecov-action@v2 -> v4
+- dep(actions/checkout): v3 -> v4
+- dep(actions/setup-node): v3 -> v4
+- dep(actions/codecov-action): v2 -> v4
+- dep(semver): bump 7.5.4 -> 7.6.0
+- chore: use new node-version `*` & `-1` syntax
 
 
 ### [1.6.1] - 2023-10-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ### Unreleased
 
 
+### [1.6.2] - 2024-02-07
+
+- dep: actions/checkout@v3 -> v4
+- dep: actions/setup-node@v3 -> v4
+- dep: use new node-version `*` & `-1` syntax
+- dep: codecov/codecov-action@v2 -> v4
+
+
 ### [1.6.1] - 2023-10-24
 
 - ci: node.js ver 16 -> 20
@@ -90,3 +98,4 @@ deps: bump versions, update dist
 [1.5.2]: https://github.com/msimerson/node-lts-versions/releases/tag/1.5.2
 [1.6.0]: https://github.com/msimerson/node-lts-versions/releases/tag/1.6.0
 [1.6.1]: https://github.com/msimerson/node-lts-versions/releases/tag/1.6.1
+[1.6.2]: https://github.com/msimerson/node-lts-versions/releases/tag/1.6.2

--- a/dist/index.js
+++ b/dist/index.js
@@ -16701,6 +16701,8 @@ const useCore = true
 
 const l=__nccwpck_require__(5694)
 
+const l=__nccwpck_require__(5694)
+
 l.fetch().then(() => {
   const lts    = l.json({lts: true})
   const active = l.json()

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "index.js",
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "semver": "^7.5.4"
+    "semver": "^7.6.0"
   },
   "devDependencies": {
-    "eslint": ">=8",
-    "mocha": ">=9"
+    "eslint": ">= 8",
+    "mocha": ">= 9"
   },
   "scripts": {
     "test": "npx mocha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lts-versions",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Get the maintained LTS versions of Node.js",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- dep(actions/checkout): v3 -> v4
- dep(actions/setup-node): v3 -> v4
- dep(actions/codecov-action): v2 -> v4
- dep(semver): bump 7.5.4 -> 7.6.0
- chore: use new node-version `*` & `-1` syntax
